### PR TITLE
Update fumo_data.json with release dates regarding AmiAmi Restock

### DIFF
--- a/fumo_data.json
+++ b/fumo_data.json
@@ -408,7 +408,8 @@
                     "id": "492",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui492_01.jpg",
                     "release_dates": [
-                        2020
+                        2020,
+                        2021
                     ],
                     "rarity": "Common",
                     "link": "https://www.gift-gift.jp/nui/nui492.html"
@@ -438,7 +439,8 @@
                     "img": "https://www.gift-gift.jp/nui/files/images/nui491_01.jpg",
                     "release_dates": [
                         2017,
-                        2020
+                        2020,
+                        2021
                     ],
                     "rarity": "Common",
                     "link": "https://www.gift-gift.jp/nui/nui491.html"
@@ -670,7 +672,8 @@
                         2017,
                         2018,
                         2019,
-                        2020
+                        2020,
+                        2021
                     ],
                     "rarity": "Common",
                     "link": "https://www.gift-gift.jp/nui/nui489.html"
@@ -701,7 +704,8 @@
                         2017,
                         2018,
                         2019,
-                        2020
+                        2020,
+                        2021
                     ],
                     "rarity": "Common",
                     "link": "https://www.gift-gift.jp/nui/nui490.html"
@@ -821,7 +825,8 @@
                     "id": "138",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui138_01.jpg",
                     "release_dates": [
-                        2011
+                        2011,
+                        2021
                     ],
                     "rarity": "Super Rare",
                     "link": "https://www.gift-gift.jp/nui/nui138.html"
@@ -839,7 +844,8 @@
                     "release_dates": [
                         2011,
                         2016,
-                        2018
+                        2018,
+                        2021
                     ],
                     "rarity": "Uncommon",
                     "link": "https://www.gift-gift.jp/nui/nui139.html"
@@ -949,7 +955,8 @@
                     "img": "https://www.gift-gift.jp/nui/files/images/nui236_01.jpg",
                     "release_dates": [
                         2013,
-                        2016
+                        2016,
+                        2021
                     ],
                     "rarity": "Super Rare",
                     "link": "https://www.gift-gift.jp/nui/nui236.html"
@@ -976,7 +983,8 @@
                     "img": "https://www.gift-gift.jp/nui/files/images/nui237_01.jpg",
                     "release_dates": [
                         2013,
-                        2015
+                        2015,
+                        2021
                     ],
                     "rarity": "Super Rare",
                     "link": "https://www.gift-gift.jp/nui/nui237.html"
@@ -997,7 +1005,8 @@
                         2016,
                         2017,
                         2018,
-                        2020
+                        2020,
+                        2021
                     ],
                     "rarity": "Common",
                     "link": "https://www.gift-gift.jp/nui/nui310.html"
@@ -1043,7 +1052,8 @@
                         2017,
                         2018,
                         2019,
-                        2020
+                        2020,
+                        2021
                     ],
                     "rarity": "Common",
                     "link": "https://www.gift-gift.jp/nui/nui493.html"
@@ -1060,7 +1070,8 @@
                     "img": "https://www.gift-gift.jp/nui/files/images/nui494_01.jpg",
                     "release_dates": [
                         2017,
-                        2020
+                        2020,
+                        2021
                     ],
                     "rarity": "Common",
                     "link": "https://www.gift-gift.jp/nui/nui494.html"
@@ -1077,7 +1088,8 @@
                     "img": "https://www.gift-gift.jp/nui/files/images/nui593_01.jpg",
                     "release_dates": [
                         2018,
-                        2019
+                        2019,
+                        2021
                     ],
                     "rarity": "Uncommon",
                     "link": "https://www.gift-gift.jp/nui/nui593.html"
@@ -1094,7 +1106,8 @@
                     "img": "https://www.gift-gift.jp/nui/files/images/9245f412ccd5e559baca9cf78d195743b8f73fb6.jpg",
                     "release_dates": [
                         2019,
-                        2020
+                        2020,
+                        2021
                     ],
                     "rarity": "Common",
                     "link": "https://www.gift-gift.jp/nui/nui644.html"
@@ -1126,7 +1139,8 @@
                     "id": "773",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui773_01.jpg",
                     "release_dates": [
-                        2020
+                        2020,
+                        2021
                     ],
                     "rarity": "Common",
                     "link": "https://www.gift-gift.jp/nui/nui773.html"


### PR DESCRIPTION
https://twitter.com/gift_news/status/1430049124993224710/photo/1

"Touhou plush series (Fumofumo Plush)
available at "Gift AmiAmi Online Branch Shop" from August 27th (Fri.) at 18:00 to September 7th, 2021 (Tues.) at 13:00 (JST)."