### PR TITLE
Added Deka Remillia 1.5 and Deka Flandre 1.5

### DIFF
--- a/fumo_data.json
+++ b/fumo_data.json
@@ -383,6 +383,16 @@
                     ],
                     "rarity": "Super Super Rare",
                     "link": "https://www.gift-gift.jp/archive/nui/nui124.html"
+                },
+                {
+                    "name": "Version 1.5",
+                    "id": "",
+                    "img": "https://img.amiami.com/images/product/main/221/GOODS-04198126.jpg",
+                    "release_dates": [
+                        2022
+                    ],
+                    "rarity": "Super Super Rare",
+                    "link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04198126"
                 }
             ]
         },
@@ -500,6 +510,16 @@
                     ],
                     "rarity": "Super Super Rare",
                     "link": "https://www.gift-gift.jp/archive/nui/nui189.html"
+                },
+                {
+                    "name": "Version 1.5",
+                    "id": "",
+                    "img": "https://img.amiami.com/images/product/main/221/GOODS-04198128.jpg",
+                    "release_dates": [
+                        2022
+                    ],
+                    "rarity": "Super Super Rare",
+                    "link": "https://www.amiami.com/eng/detail/?scode=GOODS-04198128"
                 }
             ],
             "straps": [


### PR DESCRIPTION
From the AmiAmi 2022 Deka Fumo sale.

Both are ranked as SSR since each only had 27 units in stock.

IDs were set to blank because I don't know which ones I should use.