### PR TITLE
Add Amiami as storefront

### DIFF
--- a/fumo_data.json
+++ b/fumo_data.json
@@ -2526,7 +2526,7 @@
                 "Starting from August 2021, Gift has been officially selling new fumo releases through here.",
                 "Offers shipping through DHL, EMS, and surface mail to most international locations.",
                 "Tend to experience reliability issues when traffic is high (i.e., around starting time of fumo sales).",
-                "Also has a <a href='https://www.amiami.jp/'>Japanese</a> that only ships to addresses inside Japan."
+                "Also has a <a href='https://www.amiami.jp/'>Japanese storefront</a> that only ships to addresses inside Japan."
             ]
         },
         {

--- a/fumo_data.json
+++ b/fumo_data.json
@@ -2520,6 +2520,16 @@
             ]
         },
         {
+            "name": "Amiami",
+            "link": "https://www.amiami.com/eng/",
+            "desc": [
+                "Starting from August 2021, Gift has been officially selling new fumo releases through here.",
+                "Offers shipping through DHL, EMS, and surface mail to most international locations.",
+                "Tend to experience reliability issues when traffic is high (i.e., around starting time of fumo sales).",
+                "Also has a <a href='https://www.amiami.jp/'>Japanese</a> that only ships to addresses inside Japan."
+            ]
+        },
+        {
             "name": "Suruga-ya",
             "link": "https://www.suruga-ya.jp/",
             "desc": [


### PR DESCRIPTION
When Gift has apparently moved all of its direct fumo sales from Gift Online Store to Amiami since the August 2021 release, it is quite surprising to find Amiami not listed as among the prominent storefronts for fumos. For international buyers, this is quite a big deal, since Amiami offers direct international shipping to many countries. Meanwhile, it also seems necessary to include a few warnings about the instability of the website itself under high traffic volumes when fumos are released.