### PR TITLE
Update fumos to 5 Dec, 2024, add Mannakas

### DIFF
--- a/fumo_data.json
+++ b/fumo_data.json
@@ -5,7 +5,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Reimu_Hakurei",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "001",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui001_01.jpg",
                     "release_dates": [
@@ -31,10 +31,11 @@
                     "rarity": "Rare",
                     "second_hand_cost": "High",
                     "price_range": "$80 - $120",
-                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui029.html"
+                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui029.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD-8276"
                 },
                 {
-                    "name": "Kourindou Version",
+                    "name": "Kourindou ver.",
                     "id": "345",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui345_01.jpg",
                     "release_dates": [
@@ -42,7 +43,8 @@
                         2016,
                         2017,
                         2018,
-                        2020
+                        2020,
+                        2025
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
@@ -51,7 +53,7 @@
                     "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-00099826"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "897",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui897_01.jpg",
                     "release_dates": [
@@ -63,7 +65,7 @@
                     "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04230781"
                 },
                 {
-                    "name": "Phantasmagoria of Dim. Dream Version",
+                    "name": "Phantasmagoria of Dim. Dream ver.",
                     "id": "1035",
                     "img": "https://www.gift-gift.jp/nui/files/images/42cc88423f061963c36e659d8895b881b121239b.jpg",
                     "release_dates": [
@@ -73,13 +75,14 @@
                     "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04417656"
                 },
                 {
-                    "name": "Lost Word ~ God-Summoning Shaman Version",
+                    "name": "LostWord ~ God-Summoning Shaman ver.",
                     "id": "983",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui983_01.jpg",
                     "release_dates": [
                         2023
                     ],
-                    "gift_link": "https://www.gift-gift.jp/nui/nui983.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui983.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04366745"
                 }
             ],
             "straps": [
@@ -95,7 +98,7 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui122.html"
                 },
                 {
-                    "name": "Kourindou Version",
+                    "name": "Kourindou ver.",
                     "id": "452",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui452_01.jpg",
                     "release_dates": [
@@ -107,7 +110,7 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui452.html"
                 },
                 {
-                    "name": "Plush Strap",
+                    "name": "Mini Plush",
                     "id": "745",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui745.jpg",
                     "release_dates": [
@@ -119,9 +122,21 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui745.html"
                 }
             ],
+            "mannakas": [
+                {
+                    "name": "Medium Size ver.",
+                    "id": "1113",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1113_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1113.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04499122"
+                }
+            ],
             "dekas": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "009",
                     "img": "https://www.gift-gift.jp/archive/nui/images/nui009_01.jpg",
                     "release_dates": [
@@ -136,7 +151,7 @@
                     "gift_link": "https://www.gift-gift.jp/archive/nui/nui009.html"
                 },
                 {
-                    "name": "Kourindou Version",
+                    "name": "Kourindou ver.",
                     "id": "739",
                     "img": "https://www.gift-gift.jp/nui/files/images/74192eafba17dba313c25cb6de2376c7e179450c.jpg",
                     "release_dates": [
@@ -177,7 +192,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Marisa_Kirisame",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "002",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui002_01.jpg",
                     "release_dates": [
@@ -189,7 +204,8 @@
                     ],
                     "rarity": "Uncommon",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui002.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui002.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD-2531"
                 },
                 {
                     "name": "Nendroid Plus",
@@ -200,10 +216,11 @@
                     ],
                     "rarity": "Rare",
                     "second_hand_cost": "High",
-                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui030.html"
+                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui030.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD-8277"
                 },
                 {
-                    "name": "Version 2",
+                    "name": "ver.2",
                     "id": "278",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui278_01.jpg",
                     "release_dates": [
@@ -217,14 +234,15 @@
                     "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD-2531"
                 },
                 {
-                    "name": "Kourindou Version",
+                    "name": "Kourindou ver.",
                     "id": "423",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui423_01.jpg",
                     "release_dates": [
                         2016,
                         2017,
                         2018,
-                        2020
+                        2020,
+                        2025
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
@@ -232,7 +250,7 @@
                     "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-00099828"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "898",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui898_01.jpg",
                     "release_dates": [
@@ -245,7 +263,7 @@
                     "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04230783"
                 },
                 {
-                    "name": "Lost Word ~ Witch of Scarlet Dreams Version",
+                    "name": "LostWord ~ Witch of Scarlet Dreams ver.",
                     "id": "984",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui984_01.jpg",
                     "release_dates": [
@@ -255,7 +273,7 @@
                     "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04366743"
                 },
                 {
-                    "name": "Phantasmagoria of Dim. Dream Version",
+                    "name": "Phantasmagoria of Dim. Dream ver.",
                     "id": "1036",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui1036_01.jpg",
                     "release_dates": [
@@ -278,7 +296,7 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui123.html"
                 },
                 {
-                    "name": "Kourindou Version",
+                    "name": "Kourindou ver.",
                     "id": "453",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui453_01.jpg",
                     "release_dates": [
@@ -289,7 +307,7 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui453.html"
                 },
                 {
-                    "name": "Plush Strap",
+                    "name": "Mini Plush",
                     "id": "746",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui746.jpg",
                     "release_dates": [
@@ -299,9 +317,21 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui746.html"
                 }
             ],
+            "mannakas": [
+                {
+                    "name": "Medium Size ver.",
+                    "id": "1114",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1114_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1114.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04499123"
+                }
+            ],
             "dekas": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "023",
                     "img": "https://www.gift-gift.jp/archive/nui/images/nui023_01.jpg",
                     "release_dates": [
@@ -314,7 +344,7 @@
                     "gift_link": "https://www.gift-gift.jp/archive/nui/nui023.html"
                 },
                 {
-                    "name": "Kourindou Version",
+                    "name": "Kourindou ver.",
                     "id": "740",
                     "img": "https://www.gift-gift.jp/nui/files/images/0ef10aad3fd6ea049e15659f3f14d95a3026a917.jpg",
                     "release_dates": [
@@ -331,7 +361,8 @@
                     "release_dates": [
                         2024
                     ],
-                    "gift_link": "https://www.gift-gift.jp/nui/nui1065.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1065.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04480675"
                 }
             ],
             "puppets": [
@@ -353,7 +384,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Sakuya_Izayoi",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "004",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui004_01.jpg",
                     "release_dates": [
@@ -376,10 +407,11 @@
                     ],
                     "rarity": "Rare",
                     "second_hand_cost": "High",
-                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui044.html"
+                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui044.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD-8278"
                 },
                 {
-                    "name": "Kourindou Version",
+                    "name": "Kourindou ver.",
                     "id": "356",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui356_01.jpg",
                     "release_dates": [
@@ -396,7 +428,7 @@
                     "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04230805"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "968",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui968_01.jpg",
                     "release_dates": [
@@ -406,7 +438,17 @@
                     "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04321735"
                 },
                 {
-                    "name": "Inu (Dog) Version",
+                    "name": "LostWord ~ Legendary Vampire Hunter ver.",
+                    "id": "1084",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1084_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1084.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04482584"
+                },
+                {
+                    "name": "Inu (Dog) ver.",
                     "id": "inu-sakuya",
                     "img": "https://cdn.discordapp.com/attachments/454070186405003266/550907554436481024/Diverse1252940707.png?ex=66327764&is=663125e4&hm=2750ab091d90ff90e0e660546110d1118d56bf2dc82f3db102ac6a1de4c20f20&",
                     "release_dates": [
@@ -431,7 +473,7 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui152.html"
                 },
                 {
-                    "name": "Plush Strap",
+                    "name": "Mini Plush",
                     "id": "903",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui903.jpg",
                     "release_dates": [
@@ -439,12 +481,13 @@
                     ],
                     "rarity": "Common",
                     "price_range": "$20",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui903.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui903.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04230793"
                 }
             ],
             "mannakas": [
                 {
-                    "name": "Medium-sized Version",
+                    "name": "Medium Size ver.",
                     "id": "1078",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui1078_01.jpg",
                     "release_dates:": [
@@ -456,11 +499,12 @@
             ],
             "dekas": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "853",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui853_01.jpg",
                     "release_dates": [
-                        2022
+                        2022,
+                        2023
                     ],
                     "rarity": "Super Rare",
                     "second_hand_cost": "Normal",
@@ -474,7 +518,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Remilia_Scarlet",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "005",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui005_01.jpg",
                     "release_dates": [
@@ -485,7 +529,8 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui005.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui005.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD-2533"
                 },
                 {
                     "name": "Nendroid Plus",
@@ -497,10 +542,11 @@
                     ],
                     "rarity": "Rare",
                     "second_hand_cost": "High",
-                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui105.html"
+                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui105.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD2-08451"
                 },
                 {
-                    "name": "Kourindou Version",
+                    "name": "Kourindou ver.",
                     "id": "364",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui364_01.jpg",
                     "release_dates": [
@@ -516,7 +562,7 @@
                     "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04230803"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "686",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui686_01.jpg",
                     "release_dates": [
@@ -530,7 +576,7 @@
                     "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04321734"
                 },
                 {
-                    "name": "Lost Word ~ Tiny Devil Mistress Version",
+                    "name": "LostWord ~ Tiny Devil Mistress ver.",
                     "id": "1032",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui1032_01.jpg",
                     "release_dates": [
@@ -553,7 +599,7 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui168.html"
                 },
                 {
-                    "name": "Plush Strap",
+                    "name": "Mini Plush",
                     "id": "901",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui901.jpg",
                     "release_dates": [
@@ -561,12 +607,13 @@
                     ],
                     "rarity": "Common",
                     "price_range": "$20",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui901.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui901.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04230791"
                 }
             ],
             "mannakas": [
                 {
-                    "name": "Medium-sized Version",
+                    "name": "Medium Size ver.",
                     "id": "1076",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui1076_01.jpg",
                     "release_dates": [
@@ -578,7 +625,7 @@
             ],
             "dekas": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "124",
                     "img": "https://www.gift-gift.jp/archive/nui/images/nui124_01.jpg",
                     "release_dates": [
@@ -589,7 +636,7 @@
                     "gift_link": "https://www.gift-gift.jp/archive/nui/nui124.html"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "851",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui851_01.jpg",
                     "release_dates": [
@@ -608,7 +655,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Patchouli_Knowledge",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "006",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui006_01.jpg",
                     "release_dates": [
@@ -622,7 +669,7 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui006.html"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "492",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui492_01.jpg",
                     "release_dates": [
@@ -632,12 +679,23 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui492.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui492.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04246799"
+                },
+                {
+                    "name": "Kourindou ver.",
+                    "id": "992",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui992_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui992.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04367915"
                 }
             ],
             "straps": [
                 {
-                    "name": "Plush Strap",
+                    "name": "Mini Plush",
                     "id": "943",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui943_01.jpg",
                     "release_dates": [
@@ -645,7 +703,20 @@
                     ],
                     "rarity": "Common",
                     "price_range": "$20",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui943.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui943.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04281064"
+                }
+            ],
+            "mannakas": [
+                {
+                    "name": "Medium Size ver.",
+                    "id": "1042",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1042_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1042.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04417663"
                 }
             ]
         },
@@ -654,7 +725,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Alice_Margatroid",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "007",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui007_01.jpg",
                     "release_dates": [
@@ -668,7 +739,7 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui007.html"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "491",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui491_01.jpg",
                     "release_dates": [
@@ -679,12 +750,13 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui491.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui491.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04246798"
                 }
             ],
             "straps": [
                 {
-                    "name": "Plush Strap",
+                    "name": "Mini Plush",
                     "id": "944",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui944_01.jpg",
                     "release_dates": [
@@ -692,7 +764,32 @@
                     ],
                     "rarity": "Common",
                     "price_range": "$20",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui944.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui944.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04281066"
+                }
+            ],
+            "mannakas": [
+                {
+                    "name": "Medium Size ver.",
+                    "id": "1043",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1043_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1043.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04417664"
+                }
+            ],
+            "dekas": [
+                {
+                    "name": "ver.1",
+                    "id": "965",
+                    "img": "https://www.gift-gift.jp/nui/files/images/b02fe6049518d4c250434aebe349b448a93bd3d2.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui965.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04299807"
                 }
             ]
         },
@@ -701,7 +798,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Flandre_Scarlet",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "008",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui008_01.jpg",
                     "release_dates": [
@@ -712,7 +809,8 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui008.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui008.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD-4301"
                 },
                 {
                     "name": "Nendroid Plus",
@@ -724,10 +822,11 @@
                     ],
                     "rarity": "Rare",
                     "second_hand_cost": "High",
-                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui106.html"
+                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui106.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD2-08452"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "346",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui346_01.jpg",
                     "release_dates": [
@@ -741,31 +840,28 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui346.html"
-                }
-            ],
-            "dekas": [
-                {
-                    "name": "Version 1",
-                    "id": "189",
-                    "img": "https://www.gift-gift.jp/archive/nui/images/nui189_01.jpg",
-                    "release_dates": [
-                        2012
-                    ],
-                    "rarity": "Super Super Rare",
-                    "second_hand_cost": "High",
-                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui189.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui346.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04321733"
                 },
                 {
-                    "name": "Version 1.5",
-                    "id": "852",
-                    "img": "https://www.gift-gift.jp/nui/files/images/nui852_01.jpg",
+                    "name": "LostWord ~ Vampire Pursuing the Hunter ver.",
+                    "id": "1033",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1033_01.jpg",
                     "release_dates": [
-                        2022
+                        2023
                     ],
-                    "rarity": "Super Rare",
-                    "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui852.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1033.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04417655"
+                },
+                {
+                    "name": "LostWord ~ Tiny Devil Mistress ver.",
+                    "id": "1034",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1034_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1034.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04417655"
                 }
             ],
             "straps": [
@@ -781,7 +877,7 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui181.html"
                 },
                 {
-                    "name": "Plush Strap",
+                    "name": "Mini Plush",
                     "id": "902",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui902.jpg",
                     "release_dates": [
@@ -789,7 +885,45 @@
                     ],
                     "rarity": "Common",
                     "price_range": "$20",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui902.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui902.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04230789"
+                }
+            ],
+            "mannakas": [
+                {
+                    "name": "Medium Size ver.",
+                    "id": "1077",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1077_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1077.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04480780"
+                }
+            ],
+            "dekas": [
+                {
+                    "name": "ver.1",
+                    "id": "189",
+                    "img": "https://www.gift-gift.jp/archive/nui/images/nui189_01.jpg",
+                    "release_dates": [
+                        2012
+                    ],
+                    "rarity": "Super Super Rare",
+                    "second_hand_cost": "High",
+                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui189.html"
+                },
+                {
+                    "name": "ver.1.5",
+                    "id": "852",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui852_01.jpg",
+                    "release_dates": [
+                        2022
+                    ],
+                    "rarity": "Super Rare",
+                    "second_hand_cost": "Normal",
+                    "gift_link": "https://www.gift-gift.jp/nui/nui852.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04198128"
                 }
             ]
         },
@@ -798,7 +932,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Sanae_Kochiya",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "013",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui013_01.jpg",
                     "release_dates": [
@@ -808,7 +942,8 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui013.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui013.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD-4302"
                 },
                 {
                     "name": "Nendroid Plus",
@@ -819,21 +954,24 @@
                     ],
                     "rarity": "Rare",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui045.html"
+                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui045.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD-8279"
                 },
                 {
-                    "name": "Version 2",
+                    "name": "ver.2",
                     "id": "290",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui290_01.jpg",
                     "release_dates": [
                         2014,
                         2019,
                         2020,
-                        2022
+                        2022,
+                        2024
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui290.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui290.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04428515"
                 }
             ],
             "straps": [
@@ -847,6 +985,28 @@
                     "rarity": "Rare",
                     "second_hand_cost": "Normal",
                     "gift_link": "https://www.gift-gift.jp/nui/nui153.html"
+                },
+                {
+                    "name": "Mini Plush",
+                    "id": "979",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui979_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui979.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04347185"
+                }
+            ],
+            "dekas": [
+                {
+                    "name": "ver.1",
+                    "id": "966",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui966_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui966.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04299809"
                 }
             ]
         },
@@ -855,7 +1015,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Cirno",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "014",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui014_01.jpg",
                     "release_dates": [
@@ -866,7 +1026,8 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Very High",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui014.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui014.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD-4303"
                 },
                 {
                     "name": "Nendroid Plus",
@@ -877,10 +1038,11 @@
                     ],
                     "rarity": "Rare",
                     "second_hand_cost": "Very High",
-                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui195.html"
+                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui195.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD2-35215"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "558",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui558_01.jpg",
                     "release_dates": [
@@ -888,29 +1050,55 @@
                         2019,
                         2020,
                         2021,
-                        2022
+                        2022,
+                        2024
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Very High",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui558.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui558.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04390414"
                 },
                 {
-                    "name": "Tanned Version",
-                    "id": 559,
+                    "name": "Suntanned",
+                    "id": "559",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui559_01.jpg",
                     "release_dates": [
                         2018,
                         2019,
-                        2022
+                        2022,
+                        2024
                     ],
                     "rarity": "Uncommon",
                     "second_hand_cost": "Very High",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui559.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui559.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04390416"
+                }
+            ],
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "1037",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1037_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1037.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04417659"
+                },
+                {
+                    "name": "Mini Plush Suntanned",
+                    "id": "1038",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1038_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1038.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04417660"
                 }
             ],
             "dekas": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "050",
                     "img": "https://www.gift-gift.jp/archive/nui/images/nui050_01.jpg",
                     "release_dates": [
@@ -920,6 +1108,26 @@
                     "rarity": "Super Super Rare",
                     "second_hand_cost": "Very High",
                     "gift_link": "https://www.gift-gift.jp/archive/nui/nui050.html"
+                },
+                {
+                    "name": "ver.1.5",
+                    "id": "1120",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1120_01.jpg",
+                    "release_dates": [
+                        2025
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1120.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04549459"
+                },
+                {
+                    "name": "Suntanned",
+                    "id": "1121",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1121_01.jpg",
+                    "release_dates": [
+                        2025
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1121.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04549457"
                 }
             ]
         },
@@ -928,7 +1136,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Suwako_Moriya",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "015",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui015_01.jpg",
                     "release_dates": [
@@ -938,10 +1146,11 @@
                     ],
                     "rarity": "Super Rare",
                     "second_hand_cost": "High",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui015.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui015.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD-4304"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "936",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui936_01.jpg",
                     "release_dates": [
@@ -949,7 +1158,20 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui936.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui936.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04281052"
+                }
+            ],
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "1075",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1075_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1075.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04480778"
                 }
             ]
         },
@@ -958,7 +1180,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Youmu_Konpaku",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "039",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui039_01.jpg",
                     "release_dates": [
@@ -968,10 +1190,11 @@
                     ],
                     "rarity": "Uncommon",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui039.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui039.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD-7030"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "489",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui489_01.jpg",
                     "release_dates": [
@@ -984,22 +1207,34 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui489.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui489.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04238026"
                 },
                 {
-                    "name": "Lost Word ~ Mysterious Sword Master Version",
+                    "name": "LostWord ~ Mysterious Master Swordsman ver.",
                     "id": "918",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui918.jpg",
                     "release_dates": [
                         2022
                     ],
                     "rarity": "Uncommon",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui918.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui918.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04238026"
+                },
+                {
+                    "name": "Kourindou ver.",
+                    "id": "1159",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1159_01.jpg",
+                    "release_dates": [
+                        2025
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1159.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04556575"
                 }
             ],
             "straps": [
                 {
-                    "name": "Plush Strap",
+                    "name": "Mini Plush",
                     "id": "946",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui946_01.jpg",
                     "release_dates": [
@@ -1007,12 +1242,25 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui946.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui946.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04281062"
+                }
+            ],
+            "mannakas": [
+                {
+                    "name": "Medium Size ver.",
+                    "id": "977",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui977_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui977.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04347181"
                 }
             ],
             "dekas": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "920",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui920_01.jpg",
                     "release_dates": [
@@ -1020,7 +1268,8 @@
                     ],
                     "rarity": "Super Rare",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui920.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui920.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04257768"
                 }
             ]
         },
@@ -1029,7 +1278,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Yuyuko_Saigyouji",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "040",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui040_01.jpg",
                     "release_dates": [
@@ -1039,10 +1288,11 @@
                     ],
                     "rarity": "Uncommon",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui040.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui040.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD-7031"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "490",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui490_01.jpg",
                     "release_dates": [
@@ -1055,12 +1305,23 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui490.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui490.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04270990"
+                },
+                {
+                    "name": "LostWord ~ Tiny Ghost Mistress ver.",
+                    "id": "1083",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1083_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1083.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04482582"
                 }
             ],
             "straps": [
                 {
-                    "name": "Plush Strap",
+                    "name": "Mini Plush",
                     "id": "945",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui945_01.jpg",
                     "release_dates": [
@@ -1068,12 +1329,25 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui945.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui945.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04281060"
+                }
+            ],
+            "mannakas": [
+                {
+                    "name": "Medium Size ver.",
+                    "id": "978",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui978_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui978.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04347183"
                 }
             ],
             "dekas": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "921",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui921_01.jpg",
                     "release_dates": [
@@ -1081,7 +1355,8 @@
                     ],
                     "rarity": "Super Rare",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui921.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui921.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04257769"
                 }
             ]
         },
@@ -1090,7 +1365,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Hong_Meiling",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "056",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui056_01.jpg",
                     "release_dates": [
@@ -1102,7 +1377,7 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui056.html"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "935",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui935_01.jpg",
                     "release_dates": [
@@ -1110,7 +1385,8 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui935.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui935.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04281050"
                 }
             ]
         },
@@ -1119,7 +1395,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Chen",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "080",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui080_01.jpg",
                     "release_dates": [
@@ -1132,18 +1408,32 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui080.html"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "523",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui523_01.jpg",
                     "release_dates": [
                         2017,
                         2018,
                         2020,
-                        2022
+                        2022,
+                        2025
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui523.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui523.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04483933"
+                }
+            ],
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "982",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui982_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui982.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04347191"
                 }
             ]
         },
@@ -1152,7 +1442,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Ran_Yakumo",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "081",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui081_01.jpg",
                     "release_dates": [
@@ -1165,18 +1455,32 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui081.html"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "524",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui524_01.jpg",
                     "release_dates": [
                         2017,
                         2018,
                         2020,
-                        2022
+                        2022,
+                        2025
                     ],
                     "rarity": "Rare",
                     "second_hand_cost": "High",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui524.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui524.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04483931"
+                }
+            ],
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "981",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui981_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui981.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04347189"
                 }
             ]
         },
@@ -1185,7 +1489,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Yukari_Yakumo",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "082",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui082_01.jpg",
                     "release_dates": [
@@ -1198,17 +1502,43 @@
                     "gift_link": "https://www.gift-gift.jp/nui/nui082.html"
                 },
                 {
-                    "name": "Version 1.5",
+                    "name": "ver.1.5",
                     "id": "525",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui525_01.jpg",
                     "release_dates": [
                         2017,
                         2018,
-                        2022
+                        2022,
+                        2025
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui525.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui525.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04483929"
+                },
+                {
+                    "name": "Kourindou ver.",
+                    "id": "991",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui991_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "rarity": "Common",
+                    "second_hand_cost": "Normal",
+                    "gift_link": "https://www.gift-gift.jp/nui/nui991.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04367913"
+                }
+            ],
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "980",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui980_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui980.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04347187"
                 }
             ]
         },
@@ -1217,7 +1547,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Kaguya_Houraisan",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "138",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui138_01.jpg",
                     "release_dates": [
@@ -1228,7 +1558,8 @@
                     ],
                     "rarity": "Uncommon",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui138.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui138.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04262774"
                 }
             ]
         },
@@ -1237,7 +1568,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Fujiwara_no_Mokou",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "139",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui139_01.jpg",
                     "release_dates": [
@@ -1250,7 +1581,20 @@
                     ],
                     "rarity": "Uncommon",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui139.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui139.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04262772"
+                }
+            ],
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "1072",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1072_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1072.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04480775"
                 }
             ]
         },
@@ -1259,7 +1603,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Satori_Komeiji",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "196",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui196_01.jpg",
                     "release_dates": [
@@ -1270,16 +1614,18 @@
                         2017,
                         2018,
                         2020,
-                        2022
+                        2022,
+                        2024
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui196.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui196.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04230795"
                 }
             ],
             "straps": [
                 {
-                    "name": "Plush Strap",
+                    "name": "Mini Plush",
                     "id": "808",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui808_01.jpg",
                     "release_dates": [
@@ -1287,12 +1633,26 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui808.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui808.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04287533"
+                }
+            ],
+            "mannakas": [
+                {
+                    "name": "Medium Size ver.",
+                    "id": "940",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui940_01.jpg",
+                    "release_dates": [
+                        2022,
+                        2025
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui940.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04281068"
                 }
             ],
             "dekas":  [
               {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "820",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui820_01.jpg",
                     "release_dates":[
@@ -1310,7 +1670,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Koishi_Komeiji",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "197",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui197_01.jpg",
                     "release_dates": [
@@ -1322,16 +1682,28 @@
                         2018,
                         2019,
                         2020,
-                        2022
+                        2022,
+                        2024
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui197.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui197.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04428514"
+                },
+                {
+                    "name": "LostWord ~ Spontaneous White Beauty ver.",
+                    "id": "1085",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1085_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1085.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04482586"
                 }
             ],
             "straps": [
                 {
-                    "name": "Plush Strap",
+                    "name": "Mini Plush",
                     "id": "809",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui809_01.jpg",
                     "release_dates": [
@@ -1339,12 +1711,26 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui809.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui809.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04287532"
+                }
+            ],
+            "mannakas": [
+                {
+                    "name": "Medium Size ver.",
+                    "id": "941",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui941_01.jpg",
+                    "release_dates": [
+                        2022,
+                        2025
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui941.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04281070"
                 }
             ],
             "dekas": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "821",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui821_01.jpg",
                     "release_dates": [
@@ -1353,7 +1739,8 @@
                     ],
                     "rarity": "Super Rare",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui821.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui821.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04198122"
                 }
             ]
         },
@@ -1362,7 +1749,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Reisen_Udongein_Inaba",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "236",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui236_01.jpg",
                     "release_dates": [
@@ -1374,10 +1761,11 @@
                     ],
                     "rarity": "Rare",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui236.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui236.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04262776"
                 },
                 {
-                    "name": "Hisouten Version",
+                    "name": "Hisouten ver.",
                     "id": "424",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui424_01.jpg",
                     "release_dates": [
@@ -1386,7 +1774,32 @@
                     ],
                     "rarity": "Rare",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui424.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui424.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04450140"
+                }
+            ],
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "1040",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1040_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1040.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04417662"
+                }
+            ],
+            "mannakas": [
+                {
+                    "name": "Medium Size ver.",
+                    "id": "1115",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1115_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1115.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04499124"
                 }
             ]
         },
@@ -1395,7 +1808,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Tewi_Inaba",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "237",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui237_01.jpg",
                     "release_dates": [
@@ -1407,7 +1820,8 @@
                     ],
                     "rarity": "Uncommon",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui237.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui237.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04262778"
                 }
             ]
         },
@@ -1416,7 +1830,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Hata_no_Kokoro",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "310",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui310_01.jpg",
                     "release_dates": [
@@ -1431,7 +1845,20 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui310.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui310.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04246797"
+                }
+            ],
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "1074",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1074_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1074.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04480777"
                 }
             ]
         },
@@ -1440,7 +1867,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Kasen_Ibaraki",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "454",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui454_01.jpg",
                     "release_dates": [
@@ -1451,7 +1878,8 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui454.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui454.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04437494"
                 }
             ]
         },
@@ -1468,10 +1896,11 @@
                     ],
                     "rarity": "Rare",
                     "second_hand_cost": "High",
-                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui058.html"
+                    "gift_link": "https://www.gift-gift.jp/archive/nui/nui058.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=CGD2-02592"
                 },
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "493",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui493_01.jpg",
                     "release_dates": [
@@ -1479,14 +1908,16 @@
                         2018,
                         2019,
                         2020,
-                        2021
+                        2021,
+                        2024
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui493.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui493.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04450141"
                 },
                 {
-                    "name": "Fujinroku Version",
+                    "name": "Fujinroku ver.",
                     "id": "937",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui937_01.jpg",
                     "release_dates": [
@@ -1494,7 +1925,32 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui937.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui937.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04281054"
+                }
+            ],
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "1039",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1039_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1039.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04417661"
+                }
+            ],
+            "mannakas": [
+                {
+                    "name": "Medium Size ver.",
+                    "id": "1116",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1116_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1116.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04499125"
                 }
             ]
         },
@@ -1503,7 +1959,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Hatate_Himekaidou",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "494",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui494_01.jpg",
                     "release_dates": [
@@ -1513,7 +1969,8 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui494.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui494.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04450142"
                 }
             ]
         },
@@ -1522,7 +1979,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Tenshi_Hinanawi",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "593",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui593_01.jpg",
                     "release_dates": [
@@ -1534,7 +1991,20 @@
                     ],
                     "rarity": "Uncommon",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui593.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui593.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04246800"
+                }
+            ],
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "1073",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1073_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1073.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04480776"
                 }
             ]
         },
@@ -1543,7 +2013,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Shion_Yorigami",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "644",
                     "img": "https://www.gift-gift.jp/nui/files/images/9245f412ccd5e559baca9cf78d195743b8f73fb6.jpg",
                     "release_dates": [
@@ -1554,7 +2024,8 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui644.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui644.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04270992"
                 }
             ]
         },
@@ -1563,18 +2034,20 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Yuuka_Kazami",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "685",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui685_01.jpg",
                     "release_dates": [
                         2019,
                         2020,
                         2021,
-                        2022
+                        2022,
+                        2024
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui685.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui685.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04437496"
                 }
             ]
         },
@@ -1583,16 +2056,18 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Momiji_Inubashiri",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "773",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui773_01.jpg",
                     "release_dates": [
                         2020,
-                        2021
+                        2021,
+                        2024
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui773.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui773.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04450143"
                 }
             ]
         },
@@ -1601,16 +2076,18 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Eirin_Yagokoro",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "807",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui807_01.jpg",
                     "release_dates": [
                         2021,
-                        2022
+                        2022,
+                        2024
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui807.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui807.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04437498"
                 }
             ]
         },
@@ -1619,16 +2096,30 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Rumia",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "834",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui834_01.jpg",
                     "release_dates": [
                         2021,
-                        2022
+                        2022,
+                        2023
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui834.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui834.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04332108"
+                }
+            ],
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "1117",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1117_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1117.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04499126"
                 }
             ]
         },
@@ -1637,16 +2128,18 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Eiki_Shiki_Yamaxanadu",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "835",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui835_01.jpg",
                     "release_dates": [
                         2021,
-                        2022
+                        2022,
+                        2023
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui835.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui835.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04332110"
                 }
             ]
         },
@@ -1655,16 +2148,18 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Nitori_Kawashiro",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "836",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui836_01.jpg",
                     "release_dates": [
                         2021,
-                        2022
+                        2022,
+                        2023
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui836.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui836.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04332112"
                 }
             ]
         },
@@ -1673,7 +2168,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Joon_Yorigami",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "837",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui837_01.jpg",
                     "release_dates": [
@@ -1683,7 +2178,8 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui837.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui837.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04270994"
                 }
             ]
         },
@@ -1692,15 +2188,16 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Renko_Usami",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "899",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui899_01.jpg",
                     "release_dates": [
-                        2022
+                        2023
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui899.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui899.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04347177"
                 }
             ]
         },
@@ -1709,15 +2206,17 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Toyosatomimi_no_Miko",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "900",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui900_01.jpg",
                     "release_dates": [
-                        2022
+                        2022,
+                        2023
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui900.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui900.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04347179"
                 }
             ]
         },
@@ -1726,7 +2225,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Junko",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "938",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui938_01.jpg",
                     "release_dates": [
@@ -1734,7 +2233,8 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui938.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui938.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04281056"
                 }
             ]
         },
@@ -1743,7 +2243,7 @@
             "thwiki": "https://en.touhouwiki.net/wiki/Keiki_Haniyasushin",
             "regular": [
                 {
-                    "name": "Version 1",
+                    "name": "ver.1",
                     "id": "939",
                     "img": "https://www.gift-gift.jp/nui/files/images/nui939_01.jpg",
                     "release_dates": [
@@ -1751,7 +2251,296 @@
                     ],
                     "rarity": "Common",
                     "second_hand_cost": "Normal",
-                    "gift_link": "https://www.gift-gift.jp/nui/nui939.html"
+                    "gift_link": "https://www.gift-gift.jp/nui/nui939.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04281058"
+                }
+            ]
+        },
+        {
+            "ch_name": "Maribel Hearn",
+            "thwiki": "https://en.touhouwiki.net/wiki/Maribel_Hearn",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "973",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui973_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui973.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04347169"
+                }
+            ]
+        },
+        {
+            "ch_name": "Ibuki Suika",
+            "thwiki": "https://en.touhouwiki.net/wiki/Suika_Ibuki",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "974",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui974_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui974.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04347171"
+                }
+            ]
+        },
+        {
+            "ch_name": "Mononobe no Futo",
+            "thwiki": "https://en.touhouwiki.net/wiki/Mononobe_no_Futo",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "975",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui975_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui975.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04347173"
+                }
+            ]
+        },
+        {
+            "ch_name": "Kijin Seija",
+            "thwiki": "https://en.touhouwiki.net/wiki/Seija_Kijin",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "976",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui976_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui976.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04347175"
+                }
+            ]
+        },
+        {
+            "ch_name": "Morichika Rinnosuke",
+            "thwiki": "https://en.touhouwiki.net/wiki/Rinnosuke_Morichika",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "990",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui990_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui990.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04367911"
+                }
+            ]
+        },
+        {
+            "ch_name": "Shanghai Doll",
+            "thwiki": "https://en.touhouwiki.net/wiki/Shanghai_Doll",
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "1041",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1041_01.jpg",
+                    "release_dates": [
+                        2023
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1041.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04417658"
+                }
+            ]
+        },
+        {
+            "ch_name": "Mizuhashi Parsee",
+            "thwiki": "https://en.touhouwiki.net/wiki/Parsee_Mizuhashi",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "1066",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1066_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1066.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04480769"
+                }
+            ]
+        },
+        {
+            "ch_name": "Kaenbyou Rin",
+            "thwiki": "https://en.touhouwiki.net/wiki/Rin_Kaenbyou",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "1067",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1067_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1067.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04480770"
+                }
+            ]
+        },
+        {
+            "ch_name": "Reiuzi Utsuho",
+            "thwiki": "https://en.touhouwiki.net/wiki/Utsuho_Reiuzi",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "1068",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1068_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1068.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04480771"
+                }
+            ]
+        },
+        {
+            "ch_name": "Houjuu Nue",
+            "thwiki": "https://en.touhouwiki.net/wiki/Nue_Houjuu",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "1070",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1070_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1070.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04480773"
+                }
+            ]
+        },
+        {
+            "ch_name": "Kishin Sagume",
+            "thwiki": "https://en.touhouwiki.net/wiki/Sagume_Kishin",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "1071",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1071_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1071.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04480774"
+                }
+            ]
+        },
+        {
+            "ch_name": "Koakuma",
+            "thwiki": "https://en.touhouwiki.net/wiki/Koakuma",
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "1118",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1118_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1118.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04499127"
+                }
+            ]
+        },
+        {
+            "ch_name": "Daiyousei",
+            "thwiki": "https://en.touhouwiki.net/wiki/Daiyousei",
+            "straps": [
+                {
+                    "name": "Mini Plush",
+                    "id": "1119",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1119_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1119.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04499128"
+                }
+            ]
+        },
+        {
+            "ch_name": "Hecatia Lapislazuli",
+            "thwiki": "https://en.touhouwiki.net/wiki/Hecatia_Lapislazuli",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "1108",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1108_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1108.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04499117"
+                }
+            ]
+        },
+        {
+            "ch_name": "Matara Okina",
+            "thwiki": "https://en.touhouwiki.net/wiki/Okina_Matara",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "1109",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1109_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1109.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04499118"
+                }
+            ]
+        },
+        {
+            "ch_name": "Tenkyuu Chimata",
+            "thwiki": "https://en.touhouwiki.net/wiki/Chimata_Tenkyuu",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "1110",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1110_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1110.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04499119"
+                }
+            ]
+        },
+        {
+            "ch_name": "Kagiyama Hina",
+            "thwiki": "https://en.touhouwiki.net/wiki/Hina_Kagiyama",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "1111",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1111_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1111.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04499120"
+                }
+            ]
+        },
+        {
+            "ch_name": "Nazrin",
+            "thwiki": "https://en.touhouwiki.net/wiki/Nazrin",
+            "regular": [
+                {
+                    "name": "ver.1",
+                    "id": "1112",
+                    "img": "https://www.gift-gift.jp/nui/files/images/nui1112_01.jpg",
+                    "release_dates": [
+                        2024
+                    ],
+                    "gift_link": "https://www.gift-gift.jp/nui/nui1112.html",
+                    "amiami_link": "https://www.amiami.com/eng/detail/?gcode=GOODS-04499121"
                 }
             ]
         }

--- a/imgfetch.js
+++ b/imgfetch.js
@@ -37,7 +37,7 @@ async function doWork() {
 
     for (let character of fumoData.characters) {
         console.log('Downloading images of ' + character.ch_name + ' fumos...');
-        for (let key of ['regular', 'straps', 'puppets', 'dekas']) {
+        for (let key of ['regular', 'straps', 'puppets', 'dekas', 'mannakas']) {
             if (character.hasOwnProperty(key)) {
                 for (let fumo of character[key]) {
                     if (fumo.id !== 'inu-sakuya') {

--- a/src/fumo_checklist.mustache
+++ b/src/fumo_checklist.mustache
@@ -73,6 +73,17 @@
                     </label>
                 </li>
                 {{/straps}}
+                {{#mannakas}}
+                <input type="checkbox" id='checkbox-{{id}}' name='checkbox-{{id}}' class="hidden checklist-checkbox" />
+                <li>
+                    <label for='checkbox-{{id}}'>
+                        <div class="checklist-item">
+                            <h5>Mannaka - {{name}}</h5>
+                            <img src='img/{{id}}.jpg' />
+                        </div>
+                    </label>
+                </li>
+                {{/mannakas}}
                 {{#dekas}}
                 <input type="checkbox" id='checkbox-{{id}}' name='checkbox-{{id}}' class="hidden checklist-checkbox" />
                 <li>


### PR DESCRIPTION
- Added many, many missing fumos
- Added AmiAmi store links to existing fumos that were missing them
- Added missing release years to fumos that were rereleased
- Enabled Mannaka fumos on the checklist
- Updated image fetcher script to pull images for Mannaka fumos
- Corrected several product names to better reflect actual product listings:
  - "Version" -> "ver."
  - "Plush Strap" -> "Mini Plush"
  - "Lost Word" -> "LostWord"
  - "Tanned" -> "Suntanned"
  - "Mysterious Sword Master -> "Mysterious Master Swordsman"
- Enforced order of "regular", "straps", "mannakas", "dekas", "puppets" in data file, for consistency